### PR TITLE
fix: fix package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,15 +42,13 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
-    "exports": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      }
+    "import": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "require": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
I've way too much time trying to figure this out...

I was trying to import the package but got the common “module not found” error. Eventually, figuring out the package.json had this small error. 